### PR TITLE
Fix cut off mobile menu buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Yara motivation</title>
     <meta name="description" content="Seu companheiro de treino definitivo" />
     <meta name="author" content="Lovable" />


### PR DESCRIPTION
Add `viewport-fit=cover` to the meta viewport tag to prevent bottom menu buttons from being cut off on iOS devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-96eec9ae-ec45-477a-9a66-37381e109b3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96eec9ae-ec45-477a-9a66-37381e109b3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

