### PR TITLE
Fix cut-off buttons on android

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -123,11 +123,11 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
     margin: 0;
     min-height: 100vh;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: max(env(safe-area-inset-bottom), 24px);
   }
 }
 
 /* Util classes mobile-friendly */
-.safe-bottom { padding-bottom: max(env(safe-area-inset-bottom), 16px); }
+.safe-bottom { padding-bottom: max(env(safe-area-inset-bottom), 24px); }
 .safe-top { padding-top: max(env(safe-area-inset-top), 0px); }
 .app-container { max-width: 640px; margin: 0 auto; }


### PR DESCRIPTION
Increase bottom safe-area padding to prevent buttons from being cut off on Android devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-368c01f2-15e0-4546-9acf-c583748d5eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-368c01f2-15e0-4546-9acf-c583748d5eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

